### PR TITLE
Add llama server inference

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -1,9 +1,9 @@
 [OpenAI]
 # Optional. Set these if you are testing OpenAI models.
-api_key = 
+api_key = 1234
 
 # Optional. Set this if you are using an alternative OpenAI compatible endpoint, like ollama running locally
-# openai_compatible_url = http://localhost:11434/v1/
+openai_compatible_url = http://localhost:8080/v1/
 
 [Huggingface]
 # Optional. This allows the script to download gated models.
@@ -62,3 +62,4 @@ ooba_request_timeout = 120
 # myrun3, Alpaca, ~/my_local_model, , None, 1, ooba, --loader transformers --n_ctx 1024 --n-gpu-layers -1, 
 # myrun4, Mistral, TheBloke/Mistral-7B-Instruct-v0.2-GGUF, , None, 1, ooba, --loader llama.cpp --n-gpu-layers -1 --tensor_split 1,3,5,7, --include ["*Q3_K_M.gguf", "*.json"]
 # myrun5, Mistral, mistralai/Mistral-7B-Instruct-v0.2, , None, 1, ooba, --loader transformers --gpu-memory 12, --exclude "*.bin"
+# myrun5, Alpaca, None, , None, 1, llama, None,

--- a/lib/run_query.py
+++ b/lib/run_query.py
@@ -44,10 +44,9 @@ def run_llama_query(prompt, prompt_format, completion_tokens, temp):
 	
 	# Your prompt and any other parameters you wish to set
 	data = {
-		# 'model': 'gpt-3.5-turbo',	
 		'prompt': formatted_prompt,
 		'n_predict': completion_tokens,
-		# 'temperature': temp
+		'temperature': temp
 	}
 	
 	# Convert your data to JSON
@@ -56,7 +55,6 @@ def run_llama_query(prompt, prompt_format, completion_tokens, temp):
 	# Set the headers, if required by the server
 	headers = {
 		'Content-Type': 'application/json',
-  		# 'Authorization': 'Bearer no-key'
 	}
 	
 	# Sending the POST request to the server

--- a/lib/util.py
+++ b/lib/util.py
@@ -108,13 +108,13 @@ def parse_batch(batch, ooba_launch_script, launch_ooba):
 			
 			# Read inference engine option from config
 			inference_engine = inference_engine.strip().lower()
-			if inference_engine not in ['transformers', 'ooba', 'openai']:
+			if inference_engine not in ['transformers', 'ooba', 'openai', 'llama']:
 				raise Exception("inference_engine in config.cfg must be transformers, openai or oobabooga.")
 			if inference_engine == 'ooba' and not ooba_launch_script:
 				raise Exception('ooba_launch_script not set in config.cfg')
 			
 			prompt_format = prompt_format.strip()
-			if inference_engine == 'transformers':
+			if inference_engine in ['transformers', 'llama']:
 				template_path = './instruction-templates/' + prompt_format + '.yaml'
 				if (not prompt_format) or not os.path.exists(template_path):
 					raise Exception('Error: prompt template not found: ' + template_path)
@@ -124,7 +124,6 @@ def parse_batch(batch, ooba_launch_script, launch_ooba):
 					template_path = ooba_dir + '/instruction-templates/' + prompt_format + '.yaml'
 					if (not prompt_format) or not os.path.exists(template_path):
 						raise Exception('Error: prompt template not found: ' + template_path)
-
 			parsed.append((
 					run_id, prompt_format, model_path, lora_path, quantization, int(n_iterations), inference_engine, ooba_params_str, include_patterns, exclude_patterns
 			))


### PR DESCRIPTION
Using the llama.cpp server currently uses the /chat/completion endpoint, preventing the selection of the appropriate prompt formatting template.  This can lead to lower-than-expected scores when the standard ChatGPT template is applied. This pull request allows for the selection of both the llama.cpp server API and a specific template from the config file.

