### PR TITLE
Start llama.cpp server

### DIFF
--- a/base_prompt2.log
+++ b/base_prompt2.log
@@ -1,0 +1,837 @@
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Sympathetic
+Incredulous
+Intimidated
+Defensive
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Sympathetic: <score>
+Incredulous: <score>
+Intimidated: <score>
+Defensive: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Ellie: So, Gabe, are you ready to lose?
+Gabe: I don't lose, Ellie. I learn.
+Ellie: Ah, the eternal student. Must be nice living in a world where failure doesn't exist.
+Gabe: Better than living in a world where success is the only thing that matters.
+Ellie: And what's wrong with wanting to succeed? 
+[End dialogue]
+
+At the end of this dialogue, Gabe would feel...
+Defensive
+Empathy
+Fear
+Condescension
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Defensive: <score>
+Empathy: <score>
+Fear: <score>
+Condescension: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:

--- a/benchmark_results.csv
+++ b/benchmark_results.csv
@@ -1,0 +1,36 @@
+Run ID, Benchmark Completed, Prompt Format, Model Path, Lora Path, Quantization, Benchmark Score, EQ-Bench Version, Num Questions Parseable, Num Iterations, Inference Engine, Ooba Params, Download Filters, Error
+myrun7,2024-03-11 09:25:54,Mistral2,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,75.55,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1,,
+myrun8,2024-03-11 09:45:44,Mistral2,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,80.71,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192,,
+myrun9,2024-03-11 09:56:51,Mistral2,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,80.71,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 4096,,
+myrun10,2024-03-11 10:08:06,Mistral2,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,80.54,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048,,
+myrun11,2024-03-11 10:22:47,Mistral,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,82.01,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048,,
+myrun12,2024-03-11 10:32:00,ChatML,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,80.4,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048,,
+myrun13,2024-03-11 10:42:53,Mistral2,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,80.66,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 1024,,
+myrun14,2024-03-11 11:49:26,Mistral,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,82.11,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 4096,,
+myrun15,2024-03-11 12:00:28,Mistral,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,81.95,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192,,
+myrun16,2024-03-11 13:05:50,Mistral,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,81.88,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 1024,,
+myrun17,2024-03-11 13:15:34,Mistral,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,75.26,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 512,,
+myrun17,2024-03-11 13:28:05,Mistral,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,82.07,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192,,
+myrun17,2024-03-11 13:39:16,Mistral3,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,81.27,v2,171.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048,,
+myrun18,2024-03-11 14:13:19,Mistral3,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,81.76,v2,169.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 1024,,
+myrun19,2024-03-11 14:22:23,Mistral3,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,74.72,v2,170.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 512,,
+myrun20,2024-03-11 14:33:29,Mistral3,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,81.21,v2,170.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 4096,,
+myrun21,2024-03-11 14:44:52,Mistral3,/home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf,,none,81.5,v2,170.0,1,llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192,,
+prompt_test2,2024-03-14 15:14:38,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:14:56,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:15:58,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:20:59,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:24:14,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:40:31,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:41:06,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:42:39,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:43:37,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:47:16,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:47:37,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:49:53,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:50:00,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:50:06,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 15:52:50,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 16:38:03,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 16:43:12,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.
+prompt_test2,2024-03-14 16:49:04,Mistral,/home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf,,none,FAILED,v2,FAILED,1,ooba,,,Ooba failed to launch.

--- a/config.cfg
+++ b/config.cfg
@@ -39,6 +39,10 @@ automatically_launch_ooba = true
 # Ooba api request timeout in seconds (default 120). Set higher if you are expecting long inference times.
 ooba_request_timeout = 120
 
+[Llama config]
+# Location of the compiled server binary, e.g. ~/llama.cpp
+server_path = 
+
 [Benchmarks to run]
 # Define benchmarks in the following format:
 # run_id, instruction_template, model_path, lora_path, quantization, n_iterations, inference_engine, ooba_params, downloader_filters
@@ -62,4 +66,4 @@ ooba_request_timeout = 120
 # myrun3, Alpaca, ~/my_local_model, , None, 1, ooba, --loader transformers --n_ctx 1024 --n-gpu-layers -1, 
 # myrun4, Mistral, TheBloke/Mistral-7B-Instruct-v0.2-GGUF, , None, 1, ooba, --loader llama.cpp --n-gpu-layers -1 --tensor_split 1,3,5,7, --include ["*Q3_K_M.gguf", "*.json"]
 # myrun5, Mistral, mistralai/Mistral-7B-Instruct-v0.2, , None, 1, ooba, --loader transformers --gpu-memory 12, --exclude "*.bin"
-# myrun6, ChatML, model_name, , None, 1, llama.cpp, None,
+# myrun6, ChatML, model_name.gguf, , None, 1, llama.cpp,--n-gpu-layers 100, ,

--- a/config.cfg
+++ b/config.cfg
@@ -1,9 +1,6 @@
 [OpenAI]
 # Optional. Set these if you are testing OpenAI models.
-api_key = 
-
-# Optional. Set this if you are using an alternative OpenAI compatible endpoint, like ollama running locally
-#openai_compatible_url = http://localhost:8080/v1/
+api_key =
 
 [Huggingface]
 # Optional. This allows the script to download gated models.
@@ -24,7 +21,8 @@ trust_remote_code = false
 
 [Oobabooga config]
 # e.g. ~/text-generation-webui/start_linux.sh
-ooba_launch_script = 
+ooba_launch_script = /home/dnhkng/Documents/LLM/text-generation-webui/start_linux.sh
+# ooba_launch_script = ~/text-generation-webui/start_linux.sh
 
 # Specify any additional oobabooga launch params (this can be overridden on a per-model basis).
 # e.g.:
@@ -39,10 +37,6 @@ automatically_launch_ooba = true
 # Ooba api request timeout in seconds (default 120). Set higher if you are expecting long inference times.
 ooba_request_timeout = 120
 
-[Llama config]
-# Location of the compiled server binary, e.g. ~/llama.cpp
-server_path = 
-
 [Benchmarks to run]
 # Define benchmarks in the following format:
 # run_id, instruction_template, model_path, lora_path, quantization, n_iterations, inference_engine, ooba_params, downloader_filters
@@ -55,7 +49,7 @@ server_path =
 # - lora_path (optional): Path to local lora adapter
 # - quantization: Using bitsandbytes package (8bit, 4bit, None)
 # - n_iterations: Number of benchmark iterations (final score will be an average)
-# - inference_engine: Set this to transformers, openai, ooba or llama.cpp.
+# - inference_engine: Set this to transformers, openai or ooba.
 # - ooba_params (optional): Any additional ooba params for loading this model (overrides the global setting above)
 # - downloader_filters (optional): Specify --include or --exclude patterns (using same syntax as huggingface-cli download)
 
@@ -65,5 +59,221 @@ server_path =
 # myrun2, Llama-v2, meta-llama/Llama-2-7b-chat-hf, /path/to/local/lora/adapter, 8bit, 3, transformers, , ,
 # myrun3, Alpaca, ~/my_local_model, , None, 1, ooba, --loader transformers --n_ctx 1024 --n-gpu-layers -1, 
 # myrun4, Mistral, TheBloke/Mistral-7B-Instruct-v0.2-GGUF, , None, 1, ooba, --loader llama.cpp --n-gpu-layers -1 --tensor_split 1,3,5,7, --include ["*Q3_K_M.gguf", "*.json"]
-# myrun5, Mistral, mistralai/Mistral-7B-Instruct-v0.2, , None, 1, ooba, --loader transformers --gpu-memory 12, --exclude "*.bin"
-# myrun6, ChatML, model_name.gguf, , None, 1, llama.cpp,--n-gpu-layers 100, ,
+# myrun5, Mistral, mistralai/Mistral-7B-Instruct-v0.2, , None, 1, ooba, , --exclude "*.bin"
+# myrun3, Mistral, /home/dnhkng/Documents/models/Mistral-7B-Instruct-v0.2, None, None, 1, ooba,  --loader exllamav2, None
+# myrun1, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2, None
+# Craftsmanship
+# 34_52, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2, None
+# 32_43, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 32 --franken_stop 43 --franken_repeat 1, None
+# 31_42, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2, None
+# 22_58, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 22 --franken_stop 58 --franken_repeat 1, None
+# 34_46, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 34 --franken_stop 46 --franken_repeat 1, None
+# 33_57, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 33 --franken_stop 57 --franken_repeat 1, None
+# 35_59, 
+# 33_51, 
+# 35_50, 
+# 34_42, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 34 --franken_stop 42 --franken_repeat 1, None
+
+
+# Creativity
+# 31_42, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 2 --franken_stop 4 --franken_repeat 1, None
+# 34_52, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2, None
+# 33_51, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 33 --franken_stop 51 --franken_repeat 1, None
+# 33_44, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 33 --franken_stop 44 --franken_repeat 1, None
+# 35_59, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 35 --franken_stop 59 --franken_repeat 1, None
+# 35_50, 
+# 40_50, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 40 --franken_stop 50 --franken_repeat 1, None
+# 32_43, 
+# 39_49, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 39 --franken_stop 49 --franken_repeat 1, None
+# 35_42, 
+
+# Consistency
+# 32_42, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 32 --franken_stop 42 --franken_repeat 1, None
+# 39_44, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2, None
+# 39_44, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 39 --franken_stop 44 --franken_repeat 1, None
+# 35_42, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 35 --franken_stop 43 --franken_repeat 1, None
+# 32_43, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 2 --franken_stop 4 --franken_repeat 1, None
+# 22_44, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 22 --franken_stop 44 --franken_repeat 1, None
+# 34_46, 
+# 31_44, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 31 --franken_stop 44 --franken_repeat 1, None
+# 24_45, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 24 --franken_stop 45 --franken_repeat 1, None
+# 27_44, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 27 --franken_stop 44 --franken_repeat 1, None
+# 37_43, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 37 --franken_stop 43 --franken_repeat 1, None
+
+
+
+# Combined
+# 31_42, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 2 --franken_stop 4 --franken_repeat 1, None
+# 32_43, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 2 --franken_stop 4 --franken_repeat 1, None
+# 34_52, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2, None
+# 32_42, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 2 --franken_stop 4 --franken_repeat 1, None
+# 35_50, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 35 --franken_stop 50 --franken_repeat 1, None
+# 35_42, 
+# 33_44, 
+# 35_59, 
+# 37_43, 
+# 34_46, 
+
+
+
+# 15_42_bad, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 15 --franken_stop 42 --franken_repeat 1, None
+# 35_59_2, Vicuna-v1.1, /home/dnhkng/Documents/models/Nous-Capybara-34B, None, None, 1, ooba,  --loader exllamav2 --franken_start 35 --franken_stop 50 --franken_repeat 2, None
+
+# Miqu_base, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+
+# Combined Both stories
+# Miqu_combined_2_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 2 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_34_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 34 --franken_stop 73 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_14_75, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 14 --franken_stop 75 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_18_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 18 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_22_49, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 22 --franken_stop 49 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_33_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 33 --franken_stop 77 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_6_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 6 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_35_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 35 --franken_stop 73 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_3_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 3 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_35_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 35 --franken_stop 77 --franken_repeat 1 --max_seq_len 8192, None
+
+
+# Combined Both stories Craftsmanship
+# Miqu_combined_Craftsmanship_14_75, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_34_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_3_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_29_75, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 29 --franken_stop 75 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_46_72, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 46 --franken_stop 72 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_14_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 14 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_23_75, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 23 --franken_stop 75 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_2_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_35_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Craftsmanship_49_66, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 49 --franken_stop 66 --franken_repeat 1 --max_seq_len 8192, None
+
+
+
+# Combined Both stories Creativity
+# Miqu_combined_Creativity_2_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_18_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_45_66, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 45 --franken_stop 66 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_35_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_47_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 47 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_40_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 40 --franken_stop 77 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_35_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_34_73 Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_24_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 24 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_51_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 51 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+
+
+
+# Combined Both stories Consistency
+# Miqu_combined_Consistency_22_49, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_12_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 12 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_3_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 3 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_24_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 24 --franken_stop 73 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_29_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 29 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_46_72, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_33_69, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 33 --franken_stop 69 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_6_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_59_74, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 59 --franken_stop 74 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Consistency_35_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+
+# Miqu_2_Creativity_27_28, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 27 --franken_stop 28 --franken_repeat 3 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_5_30, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 5 --franken_stop 30 --franken_repeat 2 --max_seq_len 8192, None
+
+# Miqu_double_5_30_73_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 5 --franken_stop 30 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_5_30_repeat, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 5 --franken_stop 30 --franken_repeat 1 --max_seq_len 8192, None
+
+# Miqu_1_Craftmanship_34_74, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 34 --franken_stop 74 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_1_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 1 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_2_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_27_42, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 27 --franken_stop 42 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_44_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 44 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_43_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 43 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_29_75, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_30_37, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 30 --franken_stop 37 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_23_74, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 23 --franken_stop 74 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Craftmanship_40_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+
+# Miqu_1_Consistency_2_78, Mistralnsistency_55_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 55 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consis, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_45_66, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_1_64, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 1 --franken_stop 64 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_48_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 48 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_73_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 73 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_49_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 49 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_34_74, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_55_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 55 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_43_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 43 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Consistency_18_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+
+# Miqu_1_Creativity_48_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 48 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_50_75, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 50 --franken_stop 75 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_44_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_1_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_4_71, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 4 --franken_stop 71 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_24_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 0 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_63_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 63 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_39_64, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 39 --franken_stop 64 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_26_36, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 26 --franken_stop 36 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_1_Creativity_30_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 30 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+
+
+# Miqu_2_Creativity_47_72, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 47 --franken_stop 72 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_46_65, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 46 --franken_stop 65 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_54_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 54 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_21_42, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 21 --franken_stop 42 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_10_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 10 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_37_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 37 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_27_28, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 27 --franken_stop 28 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_34_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 34 --franken_stop 73 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_35_77, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 35 --franken_stop 77 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Creativity_30_52, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 30 --franken_stop 52 --franken_repeat 1 --max_seq_len 8192, None
+
+
+# Senku_24_79, Mistral, /home/dnhkng/Documents/models/Senku-70B-Full-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 24 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_24_79, ChatML, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 24 --franken_stop 79 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_combined_Creativity_24_79, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 24 --franken_stop 79 --franken_repeat 2 --max_seq_len 8192, None
+
+# Miqu_2_Craftsmanship_32_77, Mistral, /49_66home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 32 --franken_stop 77 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_5_30, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 5 --franken_stop 30 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_34_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 34 --franken_stop 73 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_1_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 1 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_14_75, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 14 --franken_stop 75 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_3_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 3 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_56_64, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 56 --franken_stop 64 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_14_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 14 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_18_78, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 18 --franken_stop 78 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Craftsmanship_23_51, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 23 --franken_stop 51 --franken_repeat 1 --max_seq_len 8192, None
+
+# Miqu_2_Consistency_22_49, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 22 --franken_stop 49 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_23_45, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 23 --franken_stop 45 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_30_51, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 30 --franken_stop 51 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_30_52, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 30 --franken_stop 52 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_19_44, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 19 --franken_stop 44 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_33_69, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 33 --franken_stop 69 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_5_30, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 5 --franken_stop 30 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_14_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 14 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_3_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 3 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Consistency_11_57, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 11 --franken_stop 57 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_12_34, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 12 --franken_stop 34 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_49_54, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 49 --franken_stop 54 --franken_repeat 1 --max_seq_len 8192, None
+
+# Miqu_2_Other_37_44, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 37 --franken_stop 44 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_54_58, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 54 --franken_stop 58 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_25_38, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 25 --franken_stop 38 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_21_28, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 21 --franken_stop 28 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_27_38, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 27 --franken_stop 38 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_33_34, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 33 --franken_stop 34 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_49_70, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 49 --franken_stop 70 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_61_63, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 61 --franken_stop 63 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_22_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 22 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_62_76, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 62 --franken_stop 76 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_66_73, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 66 --franken_stop 73 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_17_18, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 17 --franken_stop 18 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_7_10, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 7 --franken_stop 10 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_13_26, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 13 --franken_stop 26 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_44_51, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 44 --franken_stop 51 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_43_50, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 43 --franken_stop 50 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_57_58, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 57 --franken_stop 58 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_0_7, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 7 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_0_2, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 0 --franken_stop 2 --franken_repeat 1 --max_seq_len 8192, None
+# Miqu_2_Other_2_4, Mistral, /home/dnhkng/Documents/models/miqu-1-70b-sf-4.0bpw-h6-exl2, None, None, 1, ooba,  --loader exllamav2 --franken_start 2 --franken_stop 4 --franken_repeat 1 --max_seq_len 8192, None
+
+gguf_test, Mistral, /home/dnhkng/Documents/LLM/llama.cpp/zephyr-7b-beta.Q5_K_M.gguf, None, None, 1, ooba, --loader llama.cpp  --n-gpu-layers 70 --max_seq_len 8192, None

--- a/config.cfg.old
+++ b/config.cfg.old
@@ -1,0 +1,90 @@
+[OpenAI]
+# Optional. Set these if you are testing OpenAI models.
+api_key = 
+
+# Optional. Set this if you are using an alternative OpenAI compatible endpoint, like ollama running locally
+#openai_compatible_url = http://localhost:8080/v1/
+
+[Huggingface]
+# Optional. This allows the script to download gated models.
+access_token =
+
+# Optional. This is where models will be downloaded to.
+# - defaults to ~/.cache/huggingface/hub
+cache_dir = 
+
+[Results upload]
+# Optional. Set this to allow uploading of results to a google sheets spreadsheet.
+# Note: this feature requires extra configuration (see README).
+google_spreadsheet_url =
+
+[Options]
+# Set to true or false
+trust_remote_code = false
+
+[Oobabooga config]
+# e.g. ~/text-generation-webui/start_linux.sh
+ooba_launch_script = ~/Documents/LLM/text-generation-webui/start_linux.sh
+
+# Specify any additional oobabooga launch params (this can be overridden on a per-model basis).
+# e.g.:
+# --auto-devices --loader llama.cpp
+ooba_params_global = 
+
+# Set to true or false. Setting to "true" only supports linux (and possibly mac).
+# If set to false, you must launch ooba yourself with --api flag and load the model yourself before running the benchmark.
+# If you are launching ooba yourself, the model_path param will be ignored, and all scheduled ooba benchmark runs will use the same model.
+automatically_launch_ooba = true
+
+# Ooba api request timeout in seconds (default 120). Set higher if you are expecting long inference times.
+ooba_request_timeout = 120
+
+[Llama config]
+# Location of the compiled server binary, e.g. ~/llama.cpp
+server_path = /home/dnhkng/Documents/LLM/llama.cpp
+
+[Benchmarks to run]
+# Define benchmarks in the following format:
+# run_id, instruction_template, model_path, lora_path, quantization, n_iterations, inference_engine, ooba_params, downloader_filters
+
+# Details:
+#
+# - run_id: A name to identify the benchmark run
+# - instruction_template: The filename of the instruction template defining the prompt format, minus the .yaml (e.g. Alpaca)
+# - model_path: Huggingface model ID, local path, or OpenAI model name
+# - lora_path (optional): Path to local lora adapter
+# - quantization: Using bitsandbytes package (8bit, 4bit, None)
+# - n_iterations: Number of benchmark iterations (final score will be an average)
+# - inference_engine: Set this to transformers, openai, ooba or llama.cpp.
+# - ooba_params (optional): Any additional ooba params for loading this model (overrides the global setting above)
+# - downloader_filters (optional): Specify --include or --exclude patterns (using same syntax as huggingface-cli download)
+
+# Examples:
+#
+# myrun1, openai_api, gpt-3.5-turbo, , , 1, openai, ,
+# myrun2, Llama-v2, meta-llama/Llama-2-7b-chat-hf, /path/to/local/lora/adapter, 8bit, 3, transformers, , ,
+# myrun3, Alpaca, ~/my_local_model, , None, 1, ooba, --loader transformers --n_ctx 1024 --n-gpu-layers -1, 
+# myrun4, Mistral, TheBloke/Mistral-7B-Instruct-v0.2-GGUF, , None, 1, ooba, --loader llama.cpp --n-gpu-layers -1 --tensor_split 1,3,5,7, --include ["*Q3_K_M.gguf", "*.json"]
+# myrun5, Mistral, mistralai/Mistral-7B-Instruct-v0.2, , None, 1, ooba, --loader transformers --gpu-memory 12, --exclude "*.bin"
+# myrun6, Mistral2, /home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf, , None, 1, llama.cpp,--n-gpu-layers 100, ,
+# myrun7, Mistral2, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1, ,
+# myrun8, Mistral2, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192, ,
+# myrun9, Mistral2, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 4096, ,
+# myrun10, Mistral2, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048, ,
+# myrun11, Mistral, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048, ,
+# myrun12, ChatML, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048, ,
+# myrun13, Mistral2, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 1024, ,
+# myrun14, Mistral, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 4096, ,
+# myrun15, Mistral, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192, ,
+# myrun16, Mistral, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 1024, ,
+# myrun17, Mistral, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 512, ,
+# myrun17, Mistral, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192, ,
+# myrun17, Mistral3, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 2048, ,
+# myrun18, Mistral3, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 1024, ,
+# myrun19, Mistral3, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 512, ,
+# myrun20, Mistral3, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 4096, ,
+# myrun21, Mistral3, /home/dnhkng/Documents/models/miqu-1-70b.q4_k_m.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 8192, ,
+
+prompt_test1, Mistral, /home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf, , None, 1, llama.cpp,--n-gpu-layers 130 -ts 1,1 --ctx-size 1024, ,
+# prompt_test2, Mistral, /home/dnhkng/Documents/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf, , None, 1, ooba, --loader llama.cpp --n-gpu-layers -1 ,
+

--- a/eq-bench.py
+++ b/eq-bench.py
@@ -177,6 +177,8 @@ def main():
 			raise Exception('Invalid ooba_request_timeout value in config.cfg')
 		ooba_request_timeout = int(ooba_request_timeout)
 
+	# llama
+	llama_server_path = config['Llama config'].get('server_path', '')
 
 	# Run benchmarks based on the config
 	n_benchmarks = 0
@@ -188,7 +190,7 @@ def main():
 	models_remaining = []
 	
 	for run_id, prompt_type, model_path, lora_path, quantization, n_iterations, \
-	inference_engine, ooba_params, include_patterns, exclude_patterns in parsed_batch:
+	inference_engine, server_params, include_patterns, exclude_patterns in parsed_batch:
 		if model_path and not os.path.exists(model_path):
 			# We only want to delete model files if they won't be used in a later benchmark.
 			# We also need to make sure we clear out the model dir if we are benchmarking the same model
@@ -199,7 +201,7 @@ def main():
 			models_remaining.append(this_model_key)
 
 	for run_id, prompt_type, model_path, lora_path, quantization, n_iterations, \
-		inference_engine, ooba_params, include_patterns, exclude_patterns in parsed_batch:
+		inference_engine, server_params, include_patterns, exclude_patterns in parsed_batch:
 		# Call the run_benchmark function
 		print('--------------')
 		print('Running benchmark', n_benchmarks + 1, 'of', len(parsed_batch))
@@ -211,6 +213,9 @@ def main():
 		print('--------------')
 		ooba_instance = None
 
+
+		print(f'{inference_engine=}')
+
 		try:
 			run_benchmark(run_id, model_path, lora_path, prompt_type, quantization, 
 								n_iterations, resume=resume, delete_cache=args.d, 
@@ -220,7 +225,8 @@ def main():
 								inference_engine=inference_engine, ooba_instance=ooba_instance, 
 								launch_ooba = launch_ooba, cache_dir=cache_dir,
 								models_to_delete=models_to_delete, models_remaining=models_remaining,
-								ooba_launch_script=ooba_launch_script, ooba_params=ooba_params,
+								ooba_launch_script=ooba_launch_script, server_params=server_params,
+								llama_server_path=llama_server_path,
 								include_patterns=include_patterns, exclude_patterns=exclude_patterns,
 								ooba_params_global=ooba_params_global, fast_download=args.f,
 								hf_access_token=hf_access_token, ooba_request_timeout=ooba_request_timeout,

--- a/instruction-templates/Mistral2.yaml
+++ b/instruction-templates/Mistral2.yaml
@@ -1,0 +1,5 @@
+user: ""
+bot: ""
+turn_template: "[INST] <|user-message|>[/INST] <|bot|><|bot-message|>"
+context: "[INST] <|system-message|>[/INST]"
+system_message: ""

--- a/instruction-templates/Mistral3.yaml
+++ b/instruction-templates/Mistral3.yaml
@@ -1,0 +1,5 @@
+user: ""
+bot: ""
+turn_template: "[INST] <|user|><|user-message|>[/INST] <|bot|><|bot-message|>"
+context: ""
+system_message: ""

--- a/lib/llama.py
+++ b/lib/llama.py
@@ -1,0 +1,55 @@
+import subprocess
+import requests
+import time
+import shlex
+
+class LlamaServer:
+    def __init__(self, llama_server_path, port = 8080, model = None):
+        # Initialize the model and process
+        self.model = model
+        self.port = port
+        self.process = None
+
+        # Define the fixed command and arguments
+        self.command = ["./server", "-m"]
+
+        # Specify the directory where the server executable is located if it's not the current directory
+        self.llama_server_path = llama_server_path
+
+    def start(self, model=None, server_params=None):
+        if model is not None:
+            self.model = model
+        command = self.command + [model]
+        command += shlex.split(server_params)
+        self.process = subprocess.Popen(command, cwd=self.llama_server_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return self.is_running()
+        
+    def is_running(self):
+        if self.process is not None:
+            attempts = 0
+            while True:
+                try:
+                    response = requests.get('http://localhost:8080/health')
+                    
+                    if response.status_code == 200:
+                        return True
+                    elif response.status_code == 503: # model is still being loaded, or at full capacity
+                        pass
+                    elif response.status_code == 500: # model failed to load
+                        self.stop() # stop the server
+                        return False
+                    else:  # server is not running
+                        return False 
+                    
+                except requests.exceptions.ConnectionError:
+                    attempts += 1
+                    if attempts > 10:
+                        return False
+
+                time.sleep(0.1)
+        return False
+
+    def stop(self):
+        self.process.terminate()
+        self.process.wait()
+        self.process = None

--- a/lib/llama.py
+++ b/lib/llama.py
@@ -2,6 +2,7 @@ import subprocess
 import requests
 import time
 import shlex
+import os
 
 class LlamaServer:
     def __init__(self, llama_server_path, port = 8080, model = None):
@@ -19,7 +20,7 @@ class LlamaServer:
     def start(self, model=None, server_params=None):
         if model is not None:
             self.model = model
-        command = self.command + [model]
+        command = [os.path.join(self.llama_server_path, 'server'), '-m'] + [model]
         command += shlex.split(server_params)
         self.process = subprocess.Popen(command, cwd=self.llama_server_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return self.is_running()

--- a/lib/ooba.py
+++ b/lib/ooba.py
@@ -11,7 +11,7 @@ import platform
 from lib.download import download_model
 
 class Ooba:
-	def __init__(self, script_path, model_path, cache_dir=None, verbose=False, trust_remote_code=False, ooba_args_global="", ooba_args="", fast_download=False, include_patterns=None, exclude_patterns=None, hf_access_token=None, load_model=True):
+	def __init__(self, script_path, model_path, cache_dir=None, verbose=False, trust_remote_code=False, ooba_args_global="", server_params="", fast_download=False, include_patterns=None, exclude_patterns=None, hf_access_token=None, load_model=True):
 		self.script_path = script_path
 		if script_path.endswith('sh'):
 			self.script_command = 'bash'
@@ -25,7 +25,7 @@ class Ooba:
 		self.verbose = verbose
 		self.trust_remote_code = trust_remote_code
 		self.ooba_args_global = ooba_args_global
-		self.ooba_args = ooba_args
+		self.ooba_args = server_params
 		self.fast_download = fast_download
 		self.include_patterns = include_patterns
 		self.exclude_patterns = exclude_patterns

--- a/lib/run_query.py
+++ b/lib/run_query.py
@@ -39,6 +39,18 @@ def run_llamacpp_query(prompt, prompt_format, completion_tokens, temp):
 	# Generate the prompt from the template
 	formatted_prompt = generate_prompt_from_template(prompt, prompt_format)		
 
+	with open('llama.cpp.formatted_prompt.log', 'a') as f:
+		f.write(formatted_prompt)
+
+	with open('llama.cpp.original_prompt.log', 'a') as f:
+		f.write(prompt)
+
+	with open('llama.cpp.stripped_prompt.log', 'a') as f:
+		p = prompt.strip()
+		formatted_p = generate_prompt_from_template(p, prompt_format)
+		f.write(formatted_p)
+
+	quit()
 	# Endpoint URL for the llama.cpp server, default is localhost and port 8080
 	url = "http://localhost:8080/completion"
 	
@@ -70,6 +82,12 @@ def run_llamacpp_query(prompt, prompt_format, completion_tokens, temp):
 
 
 def run_ooba_query(prompt, history, prompt_format, completion_tokens, temp, ooba_instance, launch_ooba, ooba_request_timeout):
+
+	print('here!')
+	with open('ooba.log', 'a') as f:
+		f.write(prompt)
+
+
 	if launch_ooba and (not ooba_instance or not ooba_instance.url):
 		raise Exception("Error: Ooba api not initialised")
 	if launch_ooba:
@@ -113,6 +131,9 @@ def run_ooba_query(prompt, history, prompt_format, completion_tokens, temp, ooba
 	except Exception as e:
 		print("Request failed.")
 		print(e)
+
+
+	quit()
 	return None
 
 
@@ -204,6 +225,9 @@ def generate_prompt_from_template(prompt, prompt_type):
 	return formatted_prompt.replace("<|user-message|>", prompt)
 
 def run_query(model_path, prompt_format, prompt, history, completion_tokens, model, tokenizer, temp, inference_engine, ooba_instance, launch_ooba, ooba_request_timeout, openai_client):
+	with open('base_prompt2.log', 'a') as f:
+		f.write(prompt)
+
 	if inference_engine == 'llama.cpp':
 		return run_llamacpp_query(prompt, prompt_format, completion_tokens, temp)
 	elif inference_engine == 'openai':

--- a/llama.cpp.formatted_prompt.log
+++ b/llama.cpp.formatted_prompt.log
@@ -1,0 +1,33 @@
+[INST] 
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+ [/INST]

--- a/llama.cpp.original_prompt.log
+++ b/llama.cpp.original_prompt.log
@@ -1,0 +1,32 @@
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:

--- a/llama.cpp.stripped_prompt.log
+++ b/llama.cpp.stripped_prompt.log
@@ -1,0 +1,31 @@
+[INST] Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer: [/INST]

--- a/llama_prompt2.log
+++ b/llama_prompt2.log
@@ -1,0 +1,1 @@
+fdfsdfdfsd

--- a/llama_prompt6.log
+++ b/llama_prompt6.log
@@ -1,0 +1,31 @@
+ [INST] Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer: [/INST] 

--- a/ooba.log
+++ b/ooba.log
@@ -1,0 +1,773 @@
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Sympathetic
+Incredulous
+Intimidated
+Defensive
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Sympathetic: <score>
+Incredulous: <score>
+Intimidated: <score>
+Defensive: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Ellie: So, Gabe, are you ready to lose?
+Gabe: I don't lose, Ellie. I learn.
+Ellie: Ah, the eternal student. Must be nice living in a world where failure doesn't exist.
+Gabe: Better than living in a world where success is the only thing that matters.
+Ellie: And what's wrong with wanting to succeed? 
+[End dialogue]
+
+At the end of this dialogue, Gabe would feel...
+Defensive
+Empathy
+Fear
+Condescension
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Defensive: <score>
+Empathy: <score>
+Fear: <score>
+Condescension: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+Robert: Sentimentality won't pay the bills, Claudia.
+Claudia: And money won't bring back the trees you've felled, Robert.
+Robert: This isn't about trees, Claudia. It's about survival. My company's survival.
+Claudia: And what of the survival of the creatures that call my land home?
+Robert: They'll adapt. They always do.
+Claudia: Not this time, Robert. I won't let you.
+Robert: You don't have a choice, Claudia. If you don't sell, I'll have it seized.
+[End dialogue]
+
+At the end of this dialogue, Claudia would feel...
+Hopeful
+Threatened
+Pity
+Defiant
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Hopeful: <score>
+Threatened: <score>
+Pity: <score>
+Defiant: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:
+
+Your task is to predict the likely emotional responses of a character in this dialogue:
+
+Robert: Claudia, you've always been the idealist. But let's be practical for once, shall we?
+Claudia: Practicality, according to you, means bulldozing everything in sight.
+Robert: It's called progress, Claudia. It's how the world works.
+Claudia: Not my world, Robert.
+Robert: Your world? You mean this...this sanctuary of yours?
+Claudia: It's more than a sanctuary. It's a testament to our parents' love for nature.
+[End dialogue]
+
+At the end of this dialogue, Robert would feel...
+Remorseful
+Indifferent
+Affectionate
+Annoyed
+
+Give each of these possible emotions a score from 0-10 for the relative intensity that they are likely to be feeling each.
+
+You must output in the following format, including headings (of course, you should give your own scores), with no additional commentary:
+
+Remorseful: <score>
+Indifferent: <score>
+Affectionate: <score>
+Annoyed: <score>
+
+
+[End of answer]
+
+Remember: zero is a valid score, meaning they are likely not feeling that emotion. You must score at least one emotion > 0.
+
+Your answer:


### PR DESCRIPTION
This PR adds starting the llama.cpp server with parameters taken from the config file.

As the parameters are in the same position as those from the ooba process, the name has been refactored from 'ooba_params' to 'server_params'.

The server is started and stopped using subprocess, but tries to follow a similar style as the code for ooba.

Note: This requires you pull and compile llama.cpp first!