### PR TITLE
Fix GPU cleanup

### DIFF
--- a/eq-bench.py
+++ b/eq-bench.py
@@ -8,6 +8,8 @@ import signal
 import sys
 import re
 import io
+import gc
+import torch
 
 ooba_instance = None
 
@@ -242,6 +244,11 @@ def main():
 				except Exception as e:
 					pass
 			raise
+
+		gc.collect()
+		gc.collect()
+
+		torch.cuda.empty_cache()
 
 		models_remaining = models_remaining[1:]
 


### PR DESCRIPTION
Fixes https://github.com/EQ-bench/EQ-Bench/issues/29

After running benchmark memory was not freed:
GPU Memory after (23894294528, 42285268992)
Now it is free:
GPU Memory after (41722183680, 42285268992)